### PR TITLE
Return all request headers in response body and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Headers set multiple times can be accessed with `.RequestHeaders`
 respond 200 'Cache-Control: {{range .RequestHeaders "Cache-Control"}}{{.}} {{else}}not set{{end}}'
 ```
 
+All header names and values can be returned with `.RequestHeadersAll`
+
+```bash
+
+respond 200 '{{range $name,$value := .RequestHeadersAll }}{{$name}}: {{$value}}|{{end}}'
+```
+
 Respond will bind to port 8080 on all interfaces. A different port can be specified:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All header names and values can be returned with `.RequestHeadersAll`
 
 ```bash
 
-respond 200 '{{range $name,$value := .RequestHeadersAll }}{{$name}}: {{$value}}|{{end}}'
+respond 200 '{{range .RequestHeadersAll }}{{.Name}}: {{.Value}}|{{end}}'
 ```
 
 Respond will bind to port 8080 on all interfaces. A different port can be specified:

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -40,6 +40,16 @@ func (r ResponseContext) RequestHeaders(key string) []string {
 	return r.requestHeader.Values(key)
 }
 
+// Return all headers and values. If multiple values are associated with a key return as a comma seperated string
+func (r ResponseContext) RequestHeadersAll() map[string]string {
+
+	h := make(map[string]string)
+	for k, v := range *r.requestHeader {
+		h[k] = strings.Join(v, ",")
+	}
+	return h
+}
+
 type LogContext struct {
 	ResponseContext
 }

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -45,6 +45,8 @@ func (r ResponseContext) RequestHeadersAll() map[string]string {
 	for k, v := range *r.requestHeader {
 		h[k] = strings.Join(v, ",")
 	}
+	// The request Header object has Host removed
+	h["Host"] = r.Host
 	return h
 }
 

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -2,11 +2,9 @@ package http
 
 import (
 	"bytes"
-	"fmt"
 	"html/template"
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"strings"
 )
 
@@ -54,7 +52,7 @@ type LogContext struct {
 	ResponseContext
 }
 
-var LogFormat = "{{.Host}} {{.Method}} {{.Path}} {{.Proto}} {{.StatusCode}} {{.Description}}"
+var LogFormat = "{{.Host}} {{.Method}} {{.Path}} {{.Proto}} {{.StatusCode}} {{.Description}} {{ range $key,$value := .RequestHeadersAll}}{{$key}}: {{$value}} {{end}}"
 
 func renderRequestLog(context LogContext) string {
 
@@ -75,11 +73,6 @@ func Handler(statusCode int, responseText string, headers map[string]string) fun
 
 	context := ResponseContext{StatusCode: statusCode}
 	return func(w http.ResponseWriter, r *http.Request) {
-		// TODO: Turn logging request headers into an option
-		requestDump, err := httputil.DumpRequest(r, true)
-		if err != nil {
-			fmt.Println(err)
-		}
 
 		for h, v := range headers {
 			w.Header().Set(h, v)
@@ -93,7 +86,6 @@ func Handler(statusCode int, responseText string, headers map[string]string) fun
 		context.Path = r.URL.String()
 
 		logContext := LogContext{ResponseContext: context}
-		log.Printf(string(requestDump))
 		log.Printf(renderRequestLog(logContext))
 
 		t, err := template.New("response").Parse(responseText)

--- a/internal/http/handler_test.go
+++ b/internal/http/handler_test.go
@@ -12,6 +12,7 @@ func TestHandler(t *testing.T) {
 	type test struct {
 		statusCode      int
 		bodyTemplate    string
+		host            string
 		responseBody    string
 		responseHeaders map[string]string
 		requestHeaders  map[string][]string
@@ -37,7 +38,8 @@ func TestHandler(t *testing.T) {
 			statusCode:     444,
 			bodyTemplate:   "{{.RequestHeader \"Host\"}}",
 			responseBody:   "example.com",
-			requestHeaders: map[string][]string{"Host": {"example.com"}},
+			requestHeaders: map[string][]string{},
+			host:           "example.com",
 		},
 		{
 			statusCode:     200,
@@ -58,10 +60,10 @@ func TestHandler(t *testing.T) {
 			statusCode:   200,
 			bodyTemplate: "{{range $name,$value := .RequestHeadersAll }}{{$name}}: {{$value}}|{{end}}",
 			responseBody: "Cache-Control: max-age=0,private|Host: example.com|User-Agent: Mosaic/0.9|",
+			host:         "example.com",
 			requestHeaders: map[string][]string{
 				"Cache-Control": {"max-age=0", "private"},
 				"User-Agent":    {"Mosaic/0.9"},
-				"Host":          {"example.com"},
 			},
 		},
 		{

--- a/internal/http/handler_test.go
+++ b/internal/http/handler_test.go
@@ -56,6 +56,16 @@ func TestHandler(t *testing.T) {
 		},
 		{
 			statusCode:   200,
+			bodyTemplate: "{{range $name,$value := .RequestHeadersAll }}{{$name}}: {{$value}}|{{end}}",
+			responseBody: "Cache-Control: max-age=0,private|Host: example.com|User-Agent: Mosaic/0.9|",
+			requestHeaders: map[string][]string{
+				"Cache-Control": {"max-age=0", "private"},
+				"User-Agent":    {"Mosaic/0.9"},
+				"Host":          {"example.com"},
+			},
+		},
+		{
+			statusCode:   200,
 			bodyTemplate: "OK",
 			responseBody: "OK",
 			responseHeaders: map[string]string{

--- a/internal/http/handler_test.go
+++ b/internal/http/handler_test.go
@@ -58,12 +58,12 @@ func TestHandler(t *testing.T) {
 		},
 		{
 			statusCode:   200,
-			bodyTemplate: "{{range $name,$value := .RequestHeadersAll }}{{$name}}: {{$value}}|{{end}}",
+			bodyTemplate: "{{range .RequestHeadersAll }}{{.Name}}: {{.Value}}|{{end}}",
 			responseBody: "Cache-Control: max-age=0,private|Host: example.com|User-Agent: Mosaic/0.9|",
 			host:         "example.com",
 			requestHeaders: map[string][]string{
-				"Cache-Control": {"max-age=0", "private"},
 				"User-Agent":    {"Mosaic/0.9"},
+				"Cache-Control": {"max-age=0", "private"},
 			},
 		},
 		{


### PR DESCRIPTION
- All Headers can be included in response template
- Include request headers in log template
- Include Host header in RequestHeadersAll
