### PR TITLE
Fix goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,11 +54,13 @@ docker_manifests:
 
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
+
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
 archives.replacments has been removed in v1.19.0
 
 https://goreleaser.com/deprecations/#archivesreplacements
